### PR TITLE
refactor query service to include addtl attributes

### DIFF
--- a/app/controllers/api/user_books_controller.rb
+++ b/app/controllers/api/user_books_controller.rb
@@ -5,7 +5,7 @@ class Api::UserBooksController < ApplicationController
   def index
     books = UserBooks::QueryService.new({finish_date: params[:finish_date], user: current_user}).search
 
-    render json: serialize_data(books)
+    render json: books
   end
 
   def show
@@ -50,6 +50,6 @@ class Api::UserBooksController < ApplicationController
 
   def serialize_data(data)
     options = { include: [:book] }
-    return UserBookSerializer.new(data, options).serializable_hash[:included].pluck(:attributes)
+    return UserBookSerializer.new(data, options).serializable_hash[:data].pluck(:attributes)
   end
 end

--- a/app/services/user_books/query_service.rb
+++ b/app/services/user_books/query_service.rb
@@ -7,15 +7,33 @@ module UserBooks
     end
 
     def search
-      if @finish_date
-        return UserBook.finished(@user)
-      else
-        return UserBook.to_read(@user)
+      list =  @finish_date ? UserBook.finished(@user) : UserBook.to_read(@user)
+      new_list = []
+      id_array = list.pluck(:id)
+      rating_array = list.pluck(:rating)
+      notes_array = list.pluck(:notes)
+
+      options = { include: [:book] }
+      books = serialize_data(list)
+
+      books.each_with_index do |book, i|
+        new_book = book.dup
+        new_book[:user_book_id] = id_array[i]
+        new_book[:user_book_rating] = rating_array[i]
+        new_book[:user_book_notes] = notes_array[i]
+        new_list << new_book
       end
+      
+      return new_list
     end
 
     private
 
     attr_reader :params
+
+    def serialize_data(data)
+      options = { include: [:book] }
+      return UserBookSerializer.new(data, options).serializable_hash[:included].pluck(:attributes)
+    end
   end
 end


### PR DESCRIPTION
disclaimer: attributes/properties, I'm talking about the (:id, :title, etc etc) stuff here but since the serializer shows them as attributes, I'll keep doing the same.

context: the serializer only returns either attributes from user_books or attributes from the book itself. it can return both but it gets messy in the frontend because the attributes are nested and I was hoping to try and fix things out in the backend instead.

currently, when I make the request for the discover, reading and finished lists, it only returns the array of books with only the book's attributes.

alright, so it turns out that I also need to keep track of attributes :id, :rating, and :notes from 'user_books' so I can make update and delete requests to the backend. Here is what I tried to do.

* pluck attributes into separate arrays
* map through the list of books and create a new object with the additional attributes attached
* save them into an array and return it

this way, I can make a request in the frontend with something like,

markAsRead(book.user_book_id) => the id will get passed into the api call, get attached to the url, and make an update/delete from there

I've been trying to do it from the serializer itself but so far I've been unsuccessful

this might be a messy solution to this problem so I'm hoping for any feedback to point me into a clearer and smoother implementation.