### PR TITLE
removed book_id alias

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,5 +7,4 @@ class Book < ApplicationRecord
   validates :publisher, presence: true
   validates :cover_image_url, presence: true
 
-  alias_attribute :book_id, :id
 end

--- a/app/serializers/book_serializer.rb
+++ b/app/serializers/book_serializer.rb
@@ -1,4 +1,4 @@
 class BookSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :book_id, :title, :author, :cover_image_url, :publisher, :synopsis
+  attributes :id, :title, :author, :cover_image_url, :publisher, :synopsis
 end


### PR DESCRIPTION
After thinking about it, `book.book_id` doesn't make much sense, so I put it back to how it was before. This alias, along with the one for `book.user_book_id` was done awhile ago to prevent confusion in frontend code. I kept the latter one because that actually did make sense to use.